### PR TITLE
Add flow block

### DIFF
--- a/.github/main.flow
+++ b/.github/main.flow
@@ -1,3 +1,8 @@
+flow "ci-on-push" {
+  on = "push"
+  resolves = "ci"
+}
+
 task "ci" {
   uses = "MSMarketplaceTest"
 }


### PR DESCRIPTION
This week, we're planning to change the way that we interpret `main.flow`. The new behavior will require a `flow` block in `main.flow`. This branch changes `main.flow` so that things will continue working for this repository.